### PR TITLE
work around tokenization bug "OPEN-FILE SECTION"

### DIFF
--- a/libgixpp/gix_esql_scanner.ll
+++ b/libgixpp/gix_esql_scanner.ll
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2021 Marco Ridoni
+* Copyright (C) 2021,2022 Marco Ridoni
 * Copyright (C) 2013 Tokyo System House Co.,Ltd.
 *
 * This library is free software; you can redistribute it and/or
@@ -144,10 +144,10 @@ LOW_VALUE "LOW\-VALUE"
 	__yy_push_state(DATA_DIVISION_STATE);
 }
 
-"WORKING-STORAGE"[ ]+"SECTION"[ ]*"." | 
-"LOCAL-STORAGE"[ ]+"SECTION"[ ]*"." |
-"LINKAGE"[ ]+"SECTION"[ ]*"." |
-"FILE"[ ]+"SECTION"[ ]*"." {
+[ ]?"WORKING-STORAGE"[ ]+"SECTION"[ ]*"." | 
+[ ]?"LOCAL-STORAGE"[ ]+"SECTION"[ ]*"." |
+[ ]?"LINKAGE"[ ]+"SECTION"[ ]*"." |
+[ ]?"FILE"[ ]+"SECTION"[ ]*"." {
         driver.startlineno = yylineno;
         driver.endlineno = yylineno;
 		driver.host_reference_list->clear();


### PR DESCRIPTION
fix #36

warning: I've only did the change, ran `make`, received a bunch of warnings for fley which I've totally ignored, then retested the issue from #3 and found that the syntax errors have gone away; no more testing was done