### PR TITLE
fix flex warning, removing unused rule

### DIFF
--- a/libgixpp/gix_esql_scanner.ll
+++ b/libgixpp/gix_esql_scanner.ll
@@ -1428,10 +1428,6 @@ LOW_VALUE "LOW\-VALUE"
      
 	//Ignore 
 }
-
-(\r\n|\n) { 
-
-}
  
 . {
 	if (strlen(yytext) == 1 && yytext[0] == '.') {


### PR DESCRIPTION
there is a rule that matches identical some lines above with explicit "for all states" matching

original warning:

> gixsql-1.0.15/libgixpp/gix_esql_scanner.ll:1432: warning, rule cannot be matched