### PR TITLE
use config.h for version constant

### DIFF
--- a/gixpp/main.cpp
+++ b/gixpp/main.cpp
@@ -1,6 +1,6 @@
 /*
 This file is part of Gix-IDE, an IDE and platform for GnuCOBOL
-Copyright (C) 2021 Marco Ridoni
+Copyright (C) 2021,2022 Marco Ridoni
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -37,7 +37,12 @@ USA.
 #define PATH_LIST_SEP ":"
 #endif
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#define GIXPP_VER PACKAGE_VERSION
+#else
 #define GIXPP_VER "1.0.16"
+#endif
 
 using namespace popl;
 


### PR DESCRIPTION
currently only optional; "of course" I suggest to at least have a minimal config.h also outside of the autoconf build system and at least define the PACKAGE_VERSION string there (and use it unconditionally in main.cpp).

Note: configure.ac currently has "1.0.16dev2",  https://github.com/mridoni/gixsql/blob/fcf53de11a45c9d7de79fbd858c026001ced47b5/configure.ac#L5 which is the reason for configure in the output and the tarball name to have a "dev2" attached.