### PR TITLE
native last rc

### DIFF
--- a/runtime/libgixsql-pgsql/DbInterfacePGSQL.h
+++ b/runtime/libgixsql-pgsql/DbInterfacePGSQL.h
@@ -87,7 +87,7 @@ private:
 
 	PGResultSetData* current_resultset_data = nullptr;
 
-	int last_rc = 0;
+	PGresultStatus last_rc = PGRES_EMPTY_QUERY;
 	std::string last_error;
 	std::string last_state;
 


### PR DESCRIPTION
.. for pg interface

something similar may likely be done for the other interfaces, too.

it helps for type checks (which is the reason that this PR may not compile clean, it is mostly thought as a reminder) and definitely helps during debugging showing enum values instead of integers which must be manually cast to the appropriate enum to follow the code better