### PR TITLE
libpgsql: fix bad row acces

### DIFF
--- a/runtime/libgixsql-pgsql/DbInterfacePGSQL.cpp
+++ b/runtime/libgixsql-pgsql/DbInterfacePGSQL.cpp
@@ -672,7 +672,10 @@ bool DbInterfacePGSQL::get_resultset_value(ResultSetContextType resultset_contex
 				return false;
 			}
 			wk_rs = (PGResultSetData*)c->getPrivateData();
-			row = wk_rs->current_row_index;	// we overwrite the row index
+			// we overwrite the row index (for ?)
+			if (wk_rs->current_row_index != -1) {
+				row = wk_rs->current_row_index;
+			}
 		}
 		break;
 
@@ -685,7 +688,8 @@ bool DbInterfacePGSQL::get_resultset_value(ResultSetContextType resultset_contex
 
 	const char* res = PQgetvalue(wk_rs->resultset, row, col);
 	if (!res) {
-		return false;
+		lib_logger->error("Cannot retrieve return statement value for row {} col {}", row, col);
+		return false;	// FIXME: this means "caller error", not a problem with the resultset value!
 	}
 
 	auto type = PQftype(wk_rs->resultset, col);


### PR DESCRIPTION
this fix may not be enough - but it gets me from an endless loop in the application ...

("next record" should be read, running into this code, getting NULL result, setting "invalid data" result, getting sqlstate 00000 from the driver [I'm creating an issue for that next], checking the state, reading the "next" record from the application, getting to the same place...)

... to an "Open cursor failed" place (which I hope to inspect tomorrow).