### PR TITLE
new[]/free mismatch

### DIFF
--- a/runtime/libgixsql-pgsql/DbInterfacePGSQL.cpp
+++ b/runtime/libgixsql-pgsql/DbInterfacePGSQL.cpp
@@ -76,7 +76,7 @@ public:
 		if (_data) {
 			for (int i = 0; i < nitems; i++) {
 				if (_data[i])
-					delete _data[i];
+					delete[] _data[i];
 			}
 			delete[] _data;
 		}


### PR DESCRIPTION
we allocate a char array -> new[] so should also free[] - found by running GIXSQLExecSelectIntoOne through valgrind

It is likely useful to run the tests through valgrind before a release.