### PR TITLE
uppercase pic symbols

### DIFF
--- a/libgixpp/gix_esql_driver.cc
+++ b/libgixpp/gix_esql_driver.cc
@@ -630,7 +630,7 @@ int gix_esql_driver::build_picture(const std::string str, cb_field_ptr pic)
 		}
 
 
-		switch (c) {
+		switch (toupper(c)) {
 			case 'X':
 				if (s_count | v_count) {
 					return 0;


### PR DESCRIPTION
It fixes the following issue, reported by Sauro Menna; fix also tested by him:

```cobol
03 TR-4 PIC x(10). <------- x lower case

03 TU-4 PIC X(10). <------- X upper case

GIXSQL CALL STATIC "GIXSQLSetResultParams" USING
GIXSQL BY VALUE 0 <------- lower case
GIXSQL BY VALUE 0
GIXSQL BY VALUE 0
GIXSQL BY VALUE 0
GIXSQL BY REFERENCE TR-4
GIXSQL BY REFERENCE 0

GIXSQL CALL STATIC "GIXSQLSetResultParams" USING
GIXSQL BY VALUE 16 <------- upper case
GIXSQL BY VALUE 10
GIXSQL BY VALUE 0
GIXSQL BY VALUE 0
GIXSQL BY REFERENCE TU-4
GIXSQL BY REFERENCE 0
```

Ideally GixSQL should also have a test verifying that 16 is used here, maybe the existing TSQL038A.