### PR TITLE
Refactor the whole project to improve portability and fix build on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,10 +61,10 @@ AM_CONDITIONAL([BUILD_WINDOWS], [test "$build_windows" = "yes"])
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE([mysql],
-  [AS_HELP_STRING([--enable-mysql], [Enable MySQL support (use libmysqlclient) @<:@no@:>@])])
+  [AS_HELP_STRING([--enable-mysql], [Enable MySQL support (use libmysqlclient) @<:@yes@:>@])])
 
 AC_ARG_ENABLE([mysql-mariadb],
-  [AS_HELP_STRING([--enable-mysql-mariadb], [Enable MySQL support (use libmariadb) @<:@yes@:>@])],
+  [AS_HELP_STRING([--enable-mysql-mariadb], [Enable MySQL support (use libmariadb) @<:@no@:>@])],
   [enable_mysql_mariadb=$enableval],
   [enable_mysql_mariadb=no])
 
@@ -97,13 +97,13 @@ AS_IF([test "$enable_mysql" != "no"],
 AS_IF([test "$enable_mysql_mariadb" != "no"],
   [PKG_CHECK_MODULES([MARIADB],
     [libmariadb],
-    [enable_mysql=yes],
+    [enable_mysql_mariadb=yes],
     [AS_IF([test "$enable_mysql_mariadb" = "yes"],
       [AC_MSG_ERROR([libmariadb required, but not found.])],
       [enable_mysql=no])])])
 
 AS_IF([test "$enable_mysql" != "no"] && [test "$enable_mysql_mariadb" != "no"],
-  [AC_MSG_ERROR(["You cannot have both of 'enable_mysql' and 'enable_mysql_mariadb'!"])])
+  [AC_MSG_ERROR(["You cannot have both of '--enable-mysql' and '--enable-mysql-mariadb'!"])])
 
 AS_IF([test "$enable_odbc" != "no"],
   [PKG_CHECK_MODULES([ODBC],
@@ -220,3 +220,11 @@ AC_CONFIG_FILES([Makefile
                  runtime/libgixsql-sqlite/Makefile
 ])
 AC_OUTPUT
+
+
+echo "== Your configuration: =========="
+echo "mysql: $enable_mysql"
+echo "mysql (mariadb): $enable_mysql_mariadb"
+echo "odbc: $enable_odbc"
+echo "postgresql: $enable_pgsql"
+echo "================================="

--- a/configure.ac
+++ b/configure.ac
@@ -49,30 +49,24 @@ build_mac=no
 
 # Detect the target system
 case "${host_os}" in
-    linux*)
-        build_linux=yes
-        ;;
     cygwin*|mingw*)
         build_windows=yes
-        ;;
-    darwin*)
-        build_mac=yes
-        ;;
-    *)
-        AC_MSG_ERROR(["OS $host_os is not supported"])
         ;;
 esac
 
 # Pass the conditionals to automake
-AM_CONDITIONAL([BUILD_LINUX], [test "$build_linux" = "yes"])
 AM_CONDITIONAL([BUILD_WINDOWS], [test "$build_windows" = "yes"])
-AM_CONDITIONAL([BUILD_OSX], [test "$build_mac" = "yes"])
 
 # Checks for libraries.
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE([mysql],
-  [AS_HELP_STRING([--enable-mysql], [Enable MySQL support @<:@yes@:>@])])
+  [AS_HELP_STRING([--enable-mysql], [Enable MySQL support (use libmysqlclient) @<:@no@:>@])])
+
+AC_ARG_ENABLE([mysql-mariadb],
+  [AS_HELP_STRING([--enable-mysql-mariadb], [Enable MySQL support (use libmariadb) @<:@yes@:>@])],
+  [enable_mysql_mariadb=$enableval],
+  [enable_mysql_mariadb=no])
 
 AC_ARG_ENABLE([odbc],
   [AS_HELP_STRING([--enable-odbc], [Enable ODBC support @<:@yes@:>@])])
@@ -100,13 +94,16 @@ AS_IF([test "$enable_mysql" != "no"],
       [AC_MSG_ERROR([libmysqlclient required, but not found.])],
       [enable_mysql=maybenot])])])
 
-AS_IF([test "$enable_mysql" != "no" && test "$enable_mysql" != "yes"],
+AS_IF([test "$enable_mysql_mariadb" != "no"],
   [PKG_CHECK_MODULES([MARIADB],
     [libmariadb],
     [enable_mysql=yes],
-    [AS_IF([test "$enable_mysql" = "yes"],
-      [AC_MSG_ERROR([libmysqlclient required, but not found.])],
+    [AS_IF([test "$enable_mysql_mariadb" = "yes"],
+      [AC_MSG_ERROR([libmariadb required, but not found.])],
       [enable_mysql=no])])])
+
+AS_IF([test "$enable_mysql" != "no"] && [test "$enable_mysql_mariadb" != "no"],
+  [AC_MSG_ERROR(["You cannot have both of 'enable_mysql' and 'enable_mysql_mariadb'!"])])
 
 AS_IF([test "$enable_odbc" != "no"],
   [PKG_CHECK_MODULES([ODBC],
@@ -131,6 +128,23 @@ AS_IF([test "$enable_oracle" != "no"], [enable_oracle=yes], [enable_oracle=no])
 
 AS_IF([test "$enable_sqlite" != "no"], [enable_sqlite=yes], [enable_sqlite=no])
 
+# Check spdlog
+PKG_CHECK_MODULES([SPDLOG],
+	[spdlog],
+	[],
+	[AC_MSG_ERROR([spdlog not found.])])
+AC_SUBST(SPDLOG_CFLAGS)
+AC_SUBST(SPDLOG_LIBS)
+
+# Check fmt
+PKG_CHECK_MODULES([FMT],
+	[fmt],
+	[],
+	[AC_MSG_ERROR([fmt not found.])])
+AC_SUBST(FMT_CFLAGS)
+AC_SUBST(FMT_LIBS)
+
+
 
 # Check if the driver ID is valid
 AS_IF([test "$with_default_driver" == "none" || test "$with_default_driver" == "odbc" || test "$with_default_driver" == "mysql" || test "$with_default_driver" == "pgsql" ] || test "$with_default_driver" == "oracle" ] || test "$with_default_driver" == "sqlite" ],
@@ -141,11 +155,12 @@ AS_IF([test "$with_default_driver" == "none" || test "$with_default_driver" == "
 
 num_drivers=0
 cur_driver=
-AS_IF([test "$enable_odbc" = "yes"],   [ ((num_drivers++)) ; cur_driver=odbc  ])
-AS_IF([test "$enable_mysql" = "yes"],  [ ((num_drivers++)) ; cur_driver=mysql ])
-AS_IF([test "$enable_pgsql" = "yes"],  [ ((num_drivers++)) ; cur_driver=pgsql ])
-AS_IF([test "$enable_oracle" = "yes"], [ ((num_drivers++)) ; cur_driver=oracle ])
-AS_IF([test "$enable_sqlite" = "yes"], [ ((num_drivers++)) ; cur_driver=sqlite ])
+AS_IF([test "$enable_odbc" = "yes"],   [ num_drivers=$((num_drivers+1)) ; cur_driver=odbc  ])
+AS_IF([test "$enable_mysql" = "yes"],  [ num_drivers=$((num_drivers+1)) ; cur_driver=mysql ])
+AS_IF([test "$enable_mysql_mariadb" = "yes"],  [ num_drivers=$((num_drivers+1)) ; cur_driver=mysql ])
+AS_IF([test "$enable_pgsql" = "yes"],  [ num_drivers=$((num_drivers+1)); cur_driver=pgsql ])
+AS_IF([test "$enable_oracle" = "yes"], [ num_drivers=$((num_drivers+1)); cur_driver=oracle ])
+AS_IF([test "$enable_sqlite" = "yes"], [ num_drivers=$((num_drivers+1)); cur_driver=sqlite ])
 
 AS_IF([test "$num_drivers" = "0" ], [ AC_MSG_ERROR([At least one DBMS driver must be enabled]) ])
 
@@ -181,6 +196,7 @@ AS_IF([test x$with_default_driver != xnone ],
 
 
 AM_CONDITIONAL([ENABLE_MYSQL],  [test "$enable_mysql" = "yes"])
+AM_CONDITIONAL([ENABLE_MYSQL],  [test "$enable_mysql_mariadb" = "yes"])
 AM_CONDITIONAL([ENABLE_ODBC],   [test "$enable_odbc" = "yes"])
 AM_CONDITIONAL([ENABLE_PGSQL],  [test "$enable_pgsql" = "yes"])
 AM_CONDITIONAL([ENABLE_ORACLE], [test "$enable_oracle" = "yes"])

--- a/gixpp/Makefile.am
+++ b/gixpp/Makefile.am
@@ -2,9 +2,14 @@
 
 bin_PROGRAMS = gixpp
 gixpp_SOURCES = main.cpp popl.hpp
-gixpp_CXXFLAGS = -std=c++17 -I.. -I $(top_srcdir)/common -I$(top_srcdir)/libcpputils -I$(top_srcdir)/libgixpp -I$(top_srcdir)/build-tools/grammar-tools
+gixpp_CXXFLAGS = -std=c++17 -I.. -I $(top_srcdir)/common -I$(top_srcdir)/libcpputils -I$(top_srcdir)/libgixpp
+
+if BUILD_WINDOWS
+gixpp_CXXFLAGS += -I$(top_srcdir)/build-tools/grammar-tools
+endif
+
 gixpp_LDFLAGS =
-gixpp_LDADD = ../libgixpp/libgixpp.a ../libcpputils/libcpputils.a -lstdc++fs
+gixpp_LDADD = ../libgixpp/libgixpp.a ../libcpputils/libcpputils.a
 
 #install-exec-hook:
 #	cp $(top_srcdir)/misc/gixsql-wrapper $(prefix)/bin/gixsql && \

--- a/libgixpp/ESQLDefinitions.h
+++ b/libgixpp/ESQLDefinitions.h
@@ -20,6 +20,7 @@ USA.
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/libgixpp/GixEsqlLexer.cpp
+++ b/libgixpp/GixEsqlLexer.cpp
@@ -50,6 +50,14 @@ static std::regex rxUserDefinedCobolWord(R"(^[A-Za-z0-9]+([\-]+[A-Za-z0-9]+)*$)"
 #define SYS_EOL "\n"
 #endif
 
+std::istream& yyinGetline(std::istream* yyin, char* buff, int max_size) {
+	return yyin->getline(buff, max_size);
+}
+
+std::istream& yyinGetline(std::istream& yyin, char* buff, int max_size) {
+	return yyin.getline(buff, max_size);
+}
+
 int GixEsqlLexer::LexerInput(char* buff, int max_size)
 {
 	char* bp;
@@ -59,7 +67,7 @@ int GixEsqlLexer::LexerInput(char* buff, int max_size)
 
 	memset(buff, 0, max_size);
 
-	while (yyin.getline(buff, max_size)) {
+	while (yyinGetline(yyin, buff, max_size)) {
 
 		cur_line_content = buff;
 

--- a/libgixpp/Makefile.am
+++ b/libgixpp/Makefile.am
@@ -9,7 +9,11 @@ libgixpp_a_SOURCES = ESQLCall.cpp  FileData.cpp  GixEsqlLexer.cpp  GixPreProcess
 		TPSourceConsolidation.h ../libcpputils/libcpputils.h ../libcpputils/CopyResolver.h \
         $(top_srcdir)/common/cobol_var_types.h $(top_srcdir)/common/varlen_defs.h $(top_srcdir)/common/cobol_var_flags.h
 
-libgixpp_a_CXXFLAGS = -std=c++17 -I.. -I$(top_srcdir)/common -I$(top_srcdir)/libcpputils -I$(top_srcdir)/build-tools/grammar-tools -I$(top_srcdir)/common
+libgixpp_a_CXXFLAGS = -std=c++17 -I.. -I$(top_srcdir)/common -I$(top_srcdir)/libcpputils -I$(top_srcdir)/common
+
+if BUILD_WINDOWS
+libgixpp_a_CXXFLAGS += -I$(top_srcdir)/build-tools/grammar-tools
+endif
 
 # sources to be build first (we actually want the bison generated headers)
 BUILT_SOURCES = gix_esql_parser.cc

--- a/runtime/libgixsql-mysql/utils.cpp
+++ b/runtime/libgixsql-mysql/utils.cpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <string.h>
 #include <stdbool.h>
-#include <malloc.h>
 #include <math.h>
 #include <algorithm> 
 #include <cctype>

--- a/runtime/libgixsql-odbc/Makefile.am
+++ b/runtime/libgixsql-odbc/Makefile.am
@@ -11,4 +11,7 @@ libgixsql_odbc_la_CXXFLAGS = $(ODBC_CFLAGS) -I$(top_srcdir)/common -I$(top_srcdi
 libgixsql_odbc_la_LIBADD = $(ODBC_LIBS) 
 endif
 
-libgixsql_odbc_la_LDFLAGS = -lfmt -lstdc++fs -no-undefined -avoid-version
+libgixsql_odbc_la_CXXFLAGS += @FMT_CFLAGS@
+
+libgixsql_odbc_la_LIBADD += @FMT_LIBS@
+libgixsql_odbc_la_LDFLAGS = -no-undefined -avoid-version

--- a/runtime/libgixsql-oracle/Makefile.am
+++ b/runtime/libgixsql-oracle/Makefile.am
@@ -9,10 +9,10 @@ libgixsql_oracle_la_SOURCES = DbInterfaceManagerOracle.cpp  DbInterfaceOracle.cp
 							 odpi/dpiRowid.c odpi/dpiSodaColl.c odpi/dpiSodaCollCursor.c odpi/dpiSodaDb.c odpi/dpiSodaDoc.c \
 							 odpi/dpiSodaDocCursor.c odpi/dpiStmt.c odpi/dpiSubscr.c odpi/dpiUtils.c odpi/dpiVar.c 
 
-libgixsql_oracle_la_CXXFLAGS = -I $(srcdir)/odpi -I$(top_srcdir)/common -I$(top_srcdir)/runtime/libgixsql -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG
+libgixsql_oracle_la_CXXFLAGS = @FMT_CFLAGS@ -I$(srcdir)/odpi -I$(top_srcdir)/common -I$(top_srcdir)/runtime/libgixsql -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG
 
-libgixsql_oracle_la_LIBADD =
-libgixsql_oracle_la_LDFLAGS = -lfmt -lstdc++fs -no-undefined -avoid-version
+libgixsql_oracle_la_LIBADD = @FMT_LIBS@
+libgixsql_oracle_la_LDFLAGS = -no-undefined -avoid-version
 
 
 

--- a/runtime/libgixsql-oracle/utils.cpp
+++ b/runtime/libgixsql-oracle/utils.cpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <string.h>
 #include <stdbool.h>
-#include <malloc.h>
 #include <math.h>
 #include <algorithm> 
 #include <cctype>

--- a/runtime/libgixsql-pgsql/Makefile.am
+++ b/runtime/libgixsql-pgsql/Makefile.am
@@ -3,8 +3,8 @@
 lib_LTLIBRARIES = libgixsql-pgsql.la 
 libgixsql_pgsql_la_SOURCES = DbInterfaceManagerPGSQL.cpp  DbInterfacePGSQL.cpp  dblib.cpp  utils.cpp DbInterfacePGSQL.h utils.h
 
-libgixsql_pgsql_la_CXXFLAGS = $(LIBPQ_CFLAGS) -I$(top_srcdir)/common -I$(top_srcdir)/runtime/libgixsql -I$(top_srcdir)/common -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG
-libgixsql_pgsql_la_LIBADD = $(LIBPQ_LIBS)
-libgixsql_pgsql_la_LDFLAGS = -lfmt -lstdc++fs -no-undefined -avoid-version
+libgixsql_pgsql_la_CXXFLAGS = $(LIBPQ_CFLAGS) @FMT_CFLAGS@ -I$(top_srcdir)/common -I$(top_srcdir)/runtime/libgixsql -I$(top_srcdir)/common -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG
+libgixsql_pgsql_la_LIBADD = $(LIBPQ_LIBS) @FMT_LIBS@
+libgixsql_pgsql_la_LDFLAGS = -no-undefined -avoid-version
 
 

--- a/runtime/libgixsql-pgsql/utils.cpp
+++ b/runtime/libgixsql-pgsql/utils.cpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <string.h>
 #include <stdbool.h>
-#include <malloc.h>
 #include <math.h>
 #include <algorithm> 
 #include <cctype>

--- a/runtime/libgixsql-sqlite/Makefile.am
+++ b/runtime/libgixsql-sqlite/Makefile.am
@@ -4,9 +4,9 @@ lib_LTLIBRARIES = libgixsql-sqlite.la
 libgixsql_sqlite_la_SOURCES = DbInterfaceManagerSQLite.cpp  DbInterfaceSQLite.cpp  dblib.cpp  utils.cpp DbInterfaceSQLite.h utils.h \
 							 sqlite3.c sqlite3.h
 
-libgixsql_sqlite_la_CXXFLAGS = -I$(top_srcdir)/common -I$(top_srcdir)/runtime/libgixsql -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG
-libgixsql_sqlite_la_LIBADD = 
-libgixsql_sqlite_la_LDFLAGS = -lfmt -lstdc++fs -no-undefined -avoid-version
+libgixsql_sqlite_la_CXXFLAGS = @FMT_CFLAGS@ -I$(top_srcdir)/common -I$(top_srcdir)/runtime/libgixsql -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG
+libgixsql_sqlite_la_LIBADD = @FMT_LIBS@
+libgixsql_sqlite_la_LDFLAGS = -no-undefined -avoid-version
 
 
 

--- a/runtime/libgixsql-sqlite/utils.cpp
+++ b/runtime/libgixsql-sqlite/utils.cpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <string.h>
 #include <stdbool.h>
-#include <malloc.h>
 #include <math.h>
 #include <algorithm> 
 #include <cctype>

--- a/runtime/libgixsql/Makefile.am
+++ b/runtime/libgixsql/Makefile.am
@@ -9,5 +9,6 @@ libgixsql_la_SOURCES = Connection.cpp  ConnectionManager.cpp  Cursor.cpp  Cursor
             $(top_srcdir)/common/cobol_var_types.h $(top_srcdir)/common/varlen_defs.h $(top_srcdir)/common/cobol_var_flags.h \
 			GlobalEnv.h GlobalEnv.cpp
 
-libgixsql_la_CXXFLAGS = -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG -I$(top_srcdir)/libgixpp -I$(top_srcdir)/common
-libgixsql_la_LDFLAGS =  -lfmt -lstdc++fs -no-undefined -avoid-version
+libgixsql_la_CXXFLAGS = -std=c++17 -DSPDLOG_FMT_EXTERNAL -DNDEBUG @FMT_CFLAGS@ @SPDLOG_CFLAGS@ -I$(top_srcdir)/libgixpp -I$(top_srcdir)/common 
+libgixsql_la_LIBADD = @FMT_LIBS@ @SPDLOG_LIBS@
+libgixsql_la_LDFLAGS = -no-undefined -avoid-version

--- a/runtime/libgixsql/SqlVar.cpp
+++ b/runtime/libgixsql/SqlVar.cpp
@@ -37,21 +37,9 @@
 
 #define DBERR_NUM_OUT_OF_RANGE		-410
 
-#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__linux__)
-#include <byteswap.h>
-#define COB_BSWAP_16(val) (bswap_16 (val))
-#define COB_BSWAP_32(val) (bswap_32(val))
-#define COB_BSWAP_64(val) (bswap_64 (val))
-#elif defined(__APPLE__)
-#include <libkern/OSByteOrder.h>
-#define COB_BSWAP_16(val) (OSSwapInt16(val))
-#define COB_BSWAP_32(val) (OSSwapInt32(val))
-#define COB_BSWAP_64(val) (OSSwapInt64(val))
-#else
-#define COB_BSWAP_16(val) (_byteswap_ushort (val))
-#define COB_BSWAP_32(val) (_byteswap_ulong (val))
-#define COB_BSWAP_64(val) (_byteswap_uint64 (val))
-#endif
+#define COB_BSWAP_16(val) bitswap16(val)
+#define COB_BSWAP_32(val) bitswap32(val)
+#define COB_BSWAP_64(val) bitswap64(val)
 
 #define CBL_FIELD_FLAG_NONE		(uint32_t)0x0
 #define CBL_FIELD_FLAG_VARLEN	(uint32_t)0x80
@@ -59,6 +47,37 @@
 #define CBL_FIELD_FLAG_AUTOTRIM	(uint32_t)0x200
 
 #define ASCII_ZERO ((unsigned char)0x30)
+
+// Reverse the bits of a uint16_t value
+uint16_t bitswap16(uint16_t value) {
+    value = (value >> 8) | (value << 8);                  // Swap bytes
+    value = ((value & 0xF0F0) >> 4) | ((value & 0x0F0F) << 4); // Swap every 4 bits
+    value = ((value & 0xCCCC) >> 2) | ((value & 0x3333) << 2); // Swap every 2 bits
+    value = ((value & 0xAAAA) >> 1) | ((value & 0x5555) << 1); // Swap every 1 bit
+    return value;
+}
+
+// Reverse the bits of a uint32_t value
+uint32_t bitswap32(uint32_t value) {
+    value = (value >> 16) | (value << 16);               // Swap high and low 16 bits
+    value = ((value & 0xFF00FF00) >> 8) | ((value & 0x00FF00FF) << 8); // Swap every 8 bits
+    value = ((value & 0xF0F0F0F0) >> 4) | ((value & 0x0F0F0F0F) << 4); // Swap every 4 bits
+    value = ((value & 0xCCCCCCCC) >> 2) | ((value & 0x33333333) << 2); // Swap every 2 bits
+    value = ((value & 0xAAAAAAAA) >> 1) | ((value & 0x55555555) << 1); // Swap every 1 bit
+    return value;
+}
+
+// Reverse the bits of a uint64_t value
+uint64_t bitswap64(uint64_t value) {
+    value = (value >> 32) | (value << 32);               // Swap high and low 32 bits
+    value = ((value & 0xFFFF0000FFFF0000ULL) >> 16) | ((value & 0x0000FFFF0000FFFFULL) << 16); // Swap every 16 bits
+    value = ((value & 0xFF00FF00FF00FF00ULL) >> 8) | ((value & 0x00FF00FF00FF00FFULL) << 8); // Swap every 8 bits
+    value = ((value & 0xF0F0F0F0F0F0F0F0ULL) >> 4) | ((value & 0x0F0F0F0F0F0F0F0FULL) << 4); // Swap every 4 bits
+    value = ((value & 0xCCCCCCCCCCCCCCCCULL) >> 2) | ((value & 0x3333333333333333ULL) << 2); // Swap every 2 bits
+    value = ((value & 0xAAAAAAAAAAAAAAAAULL) >> 1) | ((value & 0x5555555555555555ULL) << 1); // Swap every 1 bit
+    return value;
+}
+
 
 const char SqlVar::_decimal_point = [] {
     struct lconv	*lc = localeconv();

--- a/runtime/libgixsql/utils.cpp
+++ b/runtime/libgixsql/utils.cpp
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string>
 #include <stdbool.h>
-#include <malloc.h>
 #include <math.h>
 #include <algorithm> 
 #include <cctype>


### PR DESCRIPTION
*Tested on OpenBSD 7.3 and Fedora 41*

This pull request has a series of modifications, let me explain:

#### Change the system-detecting logic (configure.ac)

The original configure.ac rejects configuration if the target system is not one of: windows (cygwin/msys), linux, macos. But, actually, this project has basically nothing platform-dependent. Therefore I modified this area of logic: the script will assume the project is able to build on every systems, it just needs to have some special handling for certain platforms.

#### Get fmt and spdlog via pkg-config instead of specifing -lfmt and -lspdlog flags directly

The libraries might have different filename than we thought, or inside some other directories. For example, on OpenBSD, some libraries are located in `/usr/local/lib`, for them, additional linker flags or compiler flags are needed.

#### Give another option for enabling mariadb

So that users can specify clearly whether he wants `libmysqlclient` or `libmariadb`.

#### Remove linker flags link to libstdc++

Target platform may not use libstdc++.

#### Prevent the including of build-tools/grammar-tools/FlexLexer.h on non-windows platform

`build-tools/grammar-tools/FlexLexer.h`, this file only works with GNU systems's flex. So just use `FlexLexer.h` of the system's flex.

#### Refactor `yyin.getline` into two overloaded `yyinGetline` function (`libgixpp/GixEsqlLexer.cpp`)

In OpenBSD's flex, `yyin` is a `std::istream*` instead of a `std::istream`.

#### Remove all `#include <malloc.h>`

This is useless, because there's already `#include <stdlib.h>`. And this file is not standard C header, doesn't exist on OpenBSD and some systems.

#### Provide a unified and cross-platform bitswap implementation (`runtime/libgixsql/SqlVar.cpp`)

To find the bitswap function of every system is troublesome, and you cannot find that on some systems, for example, OpenBSD. Let use a self-implemented one.