### PR TITLE
fix: binding of COMP numeric host variables

### DIFF
--- a/gixsql-tests-nunit/data/TSQL044A.cbl
+++ b/gixsql-tests-nunit/data/TSQL044A.cbl
@@ -1,0 +1,79 @@
+       IDENTIFICATION DIVISION.
+
+       PROGRAM-ID. TSQL044A.
+
+       ENVIRONMENT DIVISION.
+
+       CONFIGURATION SECTION.
+       SOURCE-COMPUTER. IBM-AT.
+       OBJECT-COMPUTER. IBM-AT.
+
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+
+       DATA DIVISION.
+
+       FILE SECTION.
+
+       WORKING-STORAGE SECTION.
+
+           01 DATASRC PIC X(64).
+           01 DBUSR  PIC X(64).
+
+           01  H-KEY   PIC S9(9) COMP.
+           01  H-RES   PIC S9(9) COMP.
+           01  H-DISP  PIC 9(4).
+
+       EXEC SQL
+            INCLUDE SQLCA
+       END-EXEC.
+
+       PROCEDURE DIVISION.
+
+       000-CONNECT.
+
+           DISPLAY "DATASRC" UPON ENVIRONMENT-NAME.
+           ACCEPT DATASRC FROM ENVIRONMENT-VALUE.
+           DISPLAY "DATASRC_USR" UPON ENVIRONMENT-NAME.
+           ACCEPT DBUSR FROM ENVIRONMENT-VALUE.
+
+           EXEC SQL
+              CONNECT TO :DATASRC USER :DBUSR
+           END-EXEC.
+
+           IF SQLCODE <> 0 THEN
+              DISPLAY 'CONNECT SQLCODE. ' SQLCODE
+              DISPLAY 'CONNECT SQLERRM. ' SQLERRM
+              GO TO 100-EXIT
+           END-IF.
+
+       100-MAIN.
+
+      *    H-KEY is USAGE COMP (binary). It is rendered to a display
+      *    string at runtime, so it must be bound as text, not as a raw
+      *    binary value, both as a WHERE parameter and a FETCH target.
+
+           MOVE 42 TO H-KEY.
+
+           EXEC SQL
+                SELECT FLD2 INTO :H-RES FROM TAB1
+                    WHERE FLD1 = :H-KEY
+           END-EXEC.
+
+           MOVE H-RES TO H-DISP.
+
+           DISPLAY 'SELECT SQLCODE: ' SQLCODE.
+           DISPLAY 'FLD2: ' H-DISP.
+
+           EXEC SQL
+              CONNECT RESET
+           END-EXEC.
+
+           IF SQLCODE <> 0 THEN
+              DISPLAY 'DISCONNECT SQLCODE. ' SQLCODE
+              DISPLAY 'DISCONNECT SQLERRM. ' SQLERRM
+              GO TO 100-EXIT
+           END-IF.
+
+       100-EXIT.
+             STOP RUN.

--- a/gixsql-tests-nunit/data/gixsql_test_data.xml
+++ b/gixsql-tests-nunit/data/gixsql_test_data.xml
@@ -3512,5 +3512,36 @@
 			</expected-output>
 		</test>
 
+		<test name="TSQL044A" enabled="true">
+			<description>COMP (USAGE BINARY) host variable as parameter and target</description>
+			<issue-coverage>#000</issue-coverage>
+			<group></group>
+			<architecture>all</architecture>
+			<compiler-type>all</compiler-type>
+
+			<cobol-sources>
+				<src name="TSQL044A.cbl" />
+			</cobol-sources>
+
+			<data-sources count="1" />
+			<pre-run-drop-table data-source-index="1">tab1</pre-run-drop-table>
+			<pre-run-sql-statement data-source-index="1">CREATE TABLE TAB1 (FLD1 INT, FLD2 INT)</pre-run-sql-statement>
+			<pre-run-sql-statement data-source-index="1">INSERT INTO TAB1(FLD1, FLD2) VALUES(42, 1234)</pre-run-sql-statement>
+
+			<environment>
+				<variable key="DATASRC" value="${datasource1-noauth-url}" />
+				<variable key="DATASRC_USR" value="${datasource1-username}.${datasource1-password}" />
+			</environment>
+
+			<preprocess value="true" />
+			<compile value="true" />
+			<run value="true" />
+
+			<expected-output>
+				<line>SELECT SQLCODE: +0000000000</line>
+				<line>FLD2: 1234</line>
+			</expected-output>
+		</test>
+
 	</tests>
 </test-data>

--- a/runtime/libgixsql/SqlVar.cpp
+++ b/runtime/libgixsql/SqlVar.cpp
@@ -78,9 +78,14 @@ SqlVar::SqlVar(CobolVarType _type, int _length, int _power, uint32_t _flags, voi
 	addr = _addr;
 	ind_addr = _ind_addr;
 	flags = _flags;
-	is_variable_length = (_flags & CBL_FIELD_FLAG_VARLEN);
-	is_binary = (_flags & CBL_FIELD_FLAG_BINARY);
-	is_autotrim = (_flags & CBL_FIELD_FLAG_AUTOTRIM);
+	// COMP integers are rendered to a display string by createRealData, so they
+	// must bind as text: clear the binary flag gixpp sets for USAGE BINARY.
+	if (_type == CobolVarType::COBOL_TYPE_UNSIGNED_BINARY ||
+		_type == CobolVarType::COBOL_TYPE_SIGNED_BINARY)
+		flags &= ~CBL_FIELD_FLAG_BINARY;
+	is_variable_length = (flags & CBL_FIELD_FLAG_VARLEN);
+	is_binary = (flags & CBL_FIELD_FLAG_BINARY);
+	is_autotrim = (flags & CBL_FIELD_FLAG_AUTOTRIM);
 	allocate_realdata_buffer();
 }
 
@@ -316,6 +321,9 @@ void SqlVar::createRealData()
 
 			}
 
+			// snprintf wrote a decimal string into the length-sized buffer; trim
+			// db_data_len to the text so trailing NULs aren't sent to the database.
+			db_data_len = (int)strlen((const char*)db_data_buffer.data());
 			spdlog::trace(FMT_FILE_FUNC "type: {}, length: {}, data: {}, db_data_buffer: [{}]", __FILE__, __func__, type, length, addr, std::string((const char *)db_data_buffer.data(), db_data_buffer_len));
 			break;
 
@@ -367,6 +375,9 @@ void SqlVar::createRealData()
 
 			}
 
+			// snprintf wrote a decimal string into the length-sized buffer; trim
+			// db_data_len to the text so trailing NULs aren't sent to the database.
+			db_data_len = (int)strlen((const char*)db_data_buffer.data());
 			spdlog::trace(FMT_FILE_FUNC "type: {}, length: {}, data: {}, db_data_buffer: [{}]", __FILE__, __func__, type, length, addr, std::string((const char *)db_data_buffer.data(), db_data_buffer_len));
 			break;
 


### PR DESCRIPTION
### Problem

A numeric host variable is always rendered to a decimal display string by `SqlVar::createRealData` (and parsed back by `createCobolData`), regardless of its COBOL `USAGE`. `gixpp`, however, sets `CBL_FIELD_FLAG_BINARY` for any `USAGE BINARY` item, including `COMP` integers, and every backend keys its parameter transmission on that flag:

| Backend | binary branch |
|---|---|
| ODBC | `SQL_C_BINARY` |
| SQLite | `sqlite3_bind_blob` |
| PostgreSQL | binary format / `OID_BYTEA` |
| MySQL | `MYSQL_TYPE_BLOB` |
| Oracle | `DPI_ORACLE_TYPE_BLOB` |

So a `COMP` host variable had its rendered ASCII digits (`"42"`) transmitted as raw binary. Db2/ODBC rejects this with `SQLSTATE 22003` ("numeric value out of range"); SQLite and the others silently bind a blob that never matches, so a lookup keyed on a `COMP` column returns no rows (`SQLCODE 100`). `COMP-3` was unaffected only because `gixpp` does not flag it binary.

### Fix

A single, backend-agnostic change in `SqlVar`:

- In the constructor, clear the binary flag for numeric types so every backend stays on the text path.
- Trim `db_data_len` for the `COBOL_TYPE_*_BINARY` cases so the trailing NULs left by `snprintf` in the length-sized buffer are not sent to the database.

### Test

Adds `TSQL044A` (a `COMP` host variable used as a `WHERE` parameter and a `FETCH` target). It fails on the unfixed runtime and passes with the fix, across all configured backends.

```
old runtime:   SELECT SQLCODE: +0000000100   FLD2: 0000   -> fails
fixed runtime: SELECT SQLCODE: +0000000000   FLD2: 1234   -> passes
```

### Verification

Checked against SQLite and Db2 (LUW, via unixODBC + the IBM clidriver): `COMP`, `COMP-3`, signed, `V99` decimal, negative and 8-byte values all round-trip correctly as both `WHERE`-clause parameters and `FETCH ... INTO` targets.